### PR TITLE
feat: Add RunPod Serverless support for CPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
 FROM python:3.10-slim
 
-WORKDIR /rembg
+WORKDIR /app
 
-RUN pip install --upgrade pip
-
-RUN apt-get update && apt-get install -y curl && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN python -m pip install ".[cpu,cli]"
+# Download the default model
 RUN rembg d u2net
 
-EXPOSE 7000
-ENTRYPOINT ["rembg"]
-CMD ["--help"]
+CMD ["python", "runpod_handler.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+rembg[cpu]
+runpod
+requests

--- a/runpod_handler.py
+++ b/runpod_handler.py
@@ -1,0 +1,31 @@
+import runpod
+from rembg import remove
+import requests
+from PIL import Image
+import io
+import base64
+
+def handler(job):
+    job_input = job.get('input', {})
+    image_url = job_input.get('image_url')
+
+    if not image_url:
+        return {"error": "image_url not provided"}
+
+    try:
+        response = requests.get(image_url)
+        response.raise_for_status()
+        img = Image.open(io.BytesIO(response.content))
+    except requests.exceptions.RequestException as e:
+        return {"error": f"Failed to download image: {e}"}
+    except IOError:
+        return {"error": "Invalid image format"}
+
+    output_bytes = remove(img)
+
+    buffered = io.BytesIO(output_bytes)
+    img_str = base64.b64encode(buffered.getvalue()).decode("utf-8")
+
+    return {"image": img_str}
+
+runpod.serverless.start({"handler": handler})


### PR DESCRIPTION
This commit introduces the necessary files and configurations to deploy the rembg model on RunPod Serverless with CPU support.

The changes include:
- A `runpod_handler.py` file that defines the serverless handler. The handler processes image URLs, removes the background using rembg, and returns the result as a base64 encoded string.
- A `requirements.txt` file listing the required Python dependencies, including `rembg[cpu]`, `runpod`, and `requests`.
- An updated `Dockerfile` to build the serverless worker image, which installs dependencies and sets the appropriate entry point.