### PR TITLE
fix: Remove model download from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-# Download the default model
-RUN rembg d u2net
-
 CMD ["python", "runpod_handler.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY runpod_handler.py .
 
 CMD ["python", "runpod_handler.py"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-rembg[cpu]
+rembg[cpu,cli]
 runpod
 requests


### PR DESCRIPTION
This commit removes the `RUN rembg d u2net` command from the Dockerfile. This command was causing build failures. By removing it, the model will be downloaded and cached by the rembg library on the first function invocation, which is a more robust approach.